### PR TITLE
chore(webpack externals): generate RxJS webpack externals dynamically

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
     "rxjs": "^5.0.0-beta.6",
     "symbol-observable": "^0.2.4",
     "typescript": "^1.8.10",
-    "webpack": "^1.13.1"
+    "webpack": "^1.13.1",
+    "webpack-rxjs-externals": "~0.0.3"
   }
 }

--- a/webpack.config.babel.js
+++ b/webpack.config.babel.js
@@ -1,4 +1,5 @@
 import webpack from 'webpack';
+import createRxJSExternals from 'webpack-rxjs-externals';
 
 const env = process.env.NODE_ENV;
 
@@ -13,17 +14,13 @@ const config = {
     libraryTarget: 'umd'
   },
   externals: {
-    'rxjs/Observable': 'Rx',
-    'rxjs/Subject': 'Rx',
-    'rxjs/observable/from': {
-      root: ['Rx', 'Observable'],
-    },
-    'rxjs/operator/filter': {
-      root: ['Rx', 'Observable', 'prototype']
-    },
-    'rxjs/observable/merge': {
-      root: ['Rx', 'Observable'],
-    },
+    ...createRxJSExternals(),
+    'redux': {
+      root: 'Redux',
+      commonjs2: 'redux',
+      commonjs: 'redux',
+      amd: 'redux'
+    }
   },
   plugins: [
     new webpack.optimize.OccurrenceOrderPlugin(),


### PR DESCRIPTION
The magic is here: https://github.com/jayphelps/webpack-rxjs-externals/blob/master/index.js

This allows us to not have to worry about any future imports bloating things.

Here's an example of what this outputs:

```js
{
  'rxjs/AsyncSubject': {
    root: 'Rx'
  },
  'rxjs/BehaviorSubject': {
    root: 'Rx'
  },
  'rxjs/InnerSubscriber': {
    root: 'Rx'
  },
  'rxjs/Notification': {
    root: 'Rx'
  },
  'rxjs/Observable': {
    root: 'Rx'
  },
  'rxjs/observable/ArrayLikeObservable': {
    root: 'Rx'
  },
  'rxjs/observable/ArrayObservable': {
    root: 'Rx'
  },
  'rxjs/observable/bindCallback': {
    root: ['Rx', 'Observable']
  },
  'rxjs/observable/bindNodeCallback': {
    root: ['Rx', 'Observable']
  },
  'rxjs/observable/BoundCallbackObservable': {
    root: 'Rx'
  },
  'rxjs/observable/BoundNodeCallbackObservable': {
    root: 'Rx'
  },
  'rxjs/observable/combineLatest': {
    root: ['Rx', 'Observable']
  },
  'rxjs/observable/concat': {
    root: ['Rx', 'Observable']
  },
  'rxjs/observable/ConnectableObservable': {
    root: 'Rx'
  },
  'rxjs/observable/defer': {
    root: ['Rx', 'Observable']
  },
  'rxjs/observable/DeferObservable': {
    root: 'Rx'
  },
  'rxjs/observable/dom/ajax': {
    root: ['Rx', 'Observable']
  },
  'rxjs/observable/dom/AjaxObservable': {
    root: ['Rx', 'Observable']
  },
  'rxjs/observable/dom/webSocket': {
    root: ['Rx', 'Observable']
  },
  'rxjs/observable/dom/WebSocketSubject': {
    root: ['Rx', 'Observable']
  },
  'rxjs/observable/empty': {
    root: ['Rx', 'Observable']
  },
  'rxjs/observable/EmptyObservable': {
    root: 'Rx'
  },
  'rxjs/observable/ErrorObservable': {
    root: 'Rx'
  },
  'rxjs/observable/forkJoin': {
    root: ['Rx', 'Observable']
  },
  'rxjs/observable/ForkJoinObservable': {
    root: 'Rx'
  },
  'rxjs/observable/from': {
    root: ['Rx', 'Observable']
  },
  'rxjs/observable/fromEvent': {
    root: ['Rx', 'Observable']
  },
  'rxjs/observable/FromEventObservable': {
    root: 'Rx'
  },
  'rxjs/observable/fromEventPattern': {
    root: ['Rx', 'Observable']
  },
  'rxjs/observable/FromEventPatternObservable': {
    root: 'Rx'
  },
  'rxjs/observable/FromObservable': {
    root: 'Rx'
  },
  'rxjs/observable/fromPromise': {
    root: ['Rx', 'Observable']
  },
  'rxjs/observable/GenerateObservable': {
    root: 'Rx'
  },
  'rxjs/observable/if': {
    root: ['Rx', 'Observable']
  },
  'rxjs/observable/IfObservable': {
    root: 'Rx'
  },
  'rxjs/observable/interval': {
    root: ['Rx', 'Observable']
  },
  'rxjs/observable/IntervalObservable': {
    root: 'Rx'
  },
  'rxjs/observable/IteratorObservable': {
    root: 'Rx'
  },
  'rxjs/observable/merge': {
    root: ['Rx', 'Observable']
  },
  'rxjs/observable/MulticastObservable': {
    root: 'Rx'
  },
  'rxjs/observable/never': {
    root: ['Rx', 'Observable']
  },
  'rxjs/observable/NeverObservable': {
    root: 'Rx'
  },
  'rxjs/observable/of': {
    root: ['Rx', 'Observable']
  },
  'rxjs/observable/PromiseObservable': {
    root: 'Rx'
  },
  'rxjs/observable/range': {
    root: ['Rx', 'Observable']
  },
  'rxjs/observable/RangeObservable': {
    root: 'Rx'
  },
  'rxjs/observable/ScalarObservable': {
    root: 'Rx'
  },
  'rxjs/observable/SubscribeOnObservable': {
    root: 'Rx'
  },
  'rxjs/observable/throw': {
    root: ['Rx', 'Observable']
  },
  'rxjs/observable/timer': {
    root: ['Rx', 'Observable']
  },
  'rxjs/observable/TimerObservable': {
    root: 'Rx'
  },
  'rxjs/observable/using': {
    root: ['Rx', 'Observable']
  },
  'rxjs/observable/UsingObservable': {
    root: 'Rx'
  },
  'rxjs/observable/zip': {
    root: ['Rx', 'Observable']
  },
  'rxjs/Observer': {
    root: 'Rx'
  },
  'rxjs/Operator': {
    root: 'Rx'
  },
  'rxjs/operator/audit': {
    root: ['Rx', 'Observable', 'prototype']
  },
  'rxjs/operator/auditTime': {
    root: ['Rx', 'Observable', 'prototype']
  },
  'rxjs/operator/buffer': {
    root: ['Rx', 'Observable', 'prototype']
  },
  'rxjs/operator/bufferCount': {
    root: ['Rx', 'Observable', 'prototype']
  },
  'rxjs/operator/bufferTime': {
    root: ['Rx', 'Observable', 'prototype']
  },
  'rxjs/operator/bufferToggle': {
    root: ['Rx', 'Observable', 'prototype']
  },
  'rxjs/operator/bufferWhen': {
    root: ['Rx', 'Observable', 'prototype']
  },
  'rxjs/operator/cache': {
    root: ['Rx', 'Observable', 'prototype']
  },
  'rxjs/operator/catch': {
    root: ['Rx', 'Observable', 'prototype']
  },
  'rxjs/operator/combineAll': {
    root: ['Rx', 'Observable', 'prototype']
  },
  'rxjs/operator/combineLatest': {
    root: ['Rx', 'Observable', 'prototype']
  },
  'rxjs/operator/concat': {
    root: ['Rx', 'Observable', 'prototype']
  },
  'rxjs/operator/concatAll': {
    root: ['Rx', 'Observable', 'prototype']
  },
  'rxjs/operator/concatMap': {
    root: ['Rx', 'Observable', 'prototype']
  },
  'rxjs/operator/concatMapTo': {
    root: ['Rx', 'Observable', 'prototype']
  },
  'rxjs/operator/count': {
    root: ['Rx', 'Observable', 'prototype']
  },
  'rxjs/operator/debounce': {
    root: ['Rx', 'Observable', 'prototype']
  },
  'rxjs/operator/debounceTime': {
    root: ['Rx', 'Observable', 'prototype']
  },
  'rxjs/operator/defaultIfEmpty': {
    root: ['Rx', 'Observable', 'prototype']
  },
  'rxjs/operator/delay': {
    root: ['Rx', 'Observable', 'prototype']
  },
  'rxjs/operator/delayWhen': {
    root: ['Rx', 'Observable', 'prototype']
  },
  'rxjs/operator/dematerialize': {
    root: ['Rx', 'Observable', 'prototype']
  },
  'rxjs/operator/distinct': {
    root: ['Rx', 'Observable', 'prototype']
  },
  'rxjs/operator/distinctKey': {
    root: ['Rx', 'Observable', 'prototype']
  },
  'rxjs/operator/distinctUntilChanged': {
    root: ['Rx', 'Observable', 'prototype']
  },
  'rxjs/operator/distinctUntilKeyChanged': {
    root: ['Rx', 'Observable', 'prototype']
  },
  'rxjs/operator/do': {
    root: ['Rx', 'Observable', 'prototype']
  },
  'rxjs/operator/elementAt': {
    root: ['Rx', 'Observable', 'prototype']
  },
  'rxjs/operator/every': {
    root: ['Rx', 'Observable', 'prototype']
  },
  'rxjs/operator/exhaust': {
    root: ['Rx', 'Observable', 'prototype']
  },
  'rxjs/operator/exhaustMap': {
    root: ['Rx', 'Observable', 'prototype']
  },
  'rxjs/operator/expand': {
    root: ['Rx', 'Observable', 'prototype']
  },
  'rxjs/operator/filter': {
    root: ['Rx', 'Observable', 'prototype']
  },
  'rxjs/operator/finally': {
    root: ['Rx', 'Observable', 'prototype']
  },
  'rxjs/operator/find': {
    root: ['Rx', 'Observable', 'prototype']
  },
  'rxjs/operator/findIndex': {
    root: ['Rx', 'Observable', 'prototype']
  },
  'rxjs/operator/first': {
    root: ['Rx', 'Observable', 'prototype']
  },
  'rxjs/operator/groupBy': {
    root: ['Rx', 'Observable', 'prototype']
  },
  'rxjs/operator/ignoreElements': {
    root: ['Rx', 'Observable', 'prototype']
  },
  'rxjs/operator/isEmpty': {
    root: ['Rx', 'Observable', 'prototype']
  },
  'rxjs/operator/last': {
    root: ['Rx', 'Observable', 'prototype']
  },
  'rxjs/operator/let': {
    root: ['Rx', 'Observable', 'prototype']
  },
  'rxjs/operator/map': {
    root: ['Rx', 'Observable', 'prototype']
  },
  'rxjs/operator/mapTo': {
    root: ['Rx', 'Observable', 'prototype']
  },
  'rxjs/operator/materialize': {
    root: ['Rx', 'Observable', 'prototype']
  },
  'rxjs/operator/max': {
    root: ['Rx', 'Observable', 'prototype']
  },
  'rxjs/operator/merge': {
    root: ['Rx', 'Observable', 'prototype']
  },
  'rxjs/operator/mergeAll': {
    root: ['Rx', 'Observable', 'prototype']
  },
  'rxjs/operator/mergeMap': {
    root: ['Rx', 'Observable', 'prototype']
  },
  'rxjs/operator/mergeMapTo': {
    root: ['Rx', 'Observable', 'prototype']
  },
  'rxjs/operator/mergeScan': {
    root: ['Rx', 'Observable', 'prototype']
  },
  'rxjs/operator/min': {
    root: ['Rx', 'Observable', 'prototype']
  },
  'rxjs/operator/multicast': {
    root: ['Rx', 'Observable', 'prototype']
  },
  'rxjs/operator/observeOn': {
    root: ['Rx', 'Observable', 'prototype']
  },
  'rxjs/operator/onErrorResumeNext': {
    root: ['Rx', 'Observable', 'prototype']
  },
  'rxjs/operator/pairwise': {
    root: ['Rx', 'Observable', 'prototype']
  },
  'rxjs/operator/partition': {
    root: ['Rx', 'Observable', 'prototype']
  },
  'rxjs/operator/pluck': {
    root: ['Rx', 'Observable', 'prototype']
  },
  'rxjs/operator/publish': {
    root: ['Rx', 'Observable', 'prototype']
  },
  'rxjs/operator/publishBehavior': {
    root: ['Rx', 'Observable', 'prototype']
  },
  'rxjs/operator/publishLast': {
    root: ['Rx', 'Observable', 'prototype']
  },
  'rxjs/operator/publishReplay': {
    root: ['Rx', 'Observable', 'prototype']
  },
  'rxjs/operator/race': {
    root: ['Rx', 'Observable', 'prototype']
  },
  'rxjs/operator/reduce': {
    root: ['Rx', 'Observable', 'prototype']
  },
  'rxjs/operator/repeat': {
    root: ['Rx', 'Observable', 'prototype']
  },
  'rxjs/operator/retry': {
    root: ['Rx', 'Observable', 'prototype']
  },
  'rxjs/operator/retryWhen': {
    root: ['Rx', 'Observable', 'prototype']
  },
  'rxjs/operator/sample': {
    root: ['Rx', 'Observable', 'prototype']
  },
  'rxjs/operator/sampleTime': {
    root: ['Rx', 'Observable', 'prototype']
  },
  'rxjs/operator/scan': {
    root: ['Rx', 'Observable', 'prototype']
  },
  'rxjs/operator/share': {
    root: ['Rx', 'Observable', 'prototype']
  },
  'rxjs/operator/single': {
    root: ['Rx', 'Observable', 'prototype']
  },
  'rxjs/operator/skip': {
    root: ['Rx', 'Observable', 'prototype']
  },
  'rxjs/operator/skipUntil': {
    root: ['Rx', 'Observable', 'prototype']
  },
  'rxjs/operator/skipWhile': {
    root: ['Rx', 'Observable', 'prototype']
  },
  'rxjs/operator/startWith': {
    root: ['Rx', 'Observable', 'prototype']
  },
  'rxjs/operator/subscribeOn': {
    root: ['Rx', 'Observable', 'prototype']
  },
  'rxjs/operator/switch': {
    root: ['Rx', 'Observable', 'prototype']
  },
  'rxjs/operator/switchMap': {
    root: ['Rx', 'Observable', 'prototype']
  },
  'rxjs/operator/switchMapTo': {
    root: ['Rx', 'Observable', 'prototype']
  },
  'rxjs/operator/take': {
    root: ['Rx', 'Observable', 'prototype']
  },
  'rxjs/operator/takeLast': {
    root: ['Rx', 'Observable', 'prototype']
  },
  'rxjs/operator/takeUntil': {
    root: ['Rx', 'Observable', 'prototype']
  },
  'rxjs/operator/takeWhile': {
    root: ['Rx', 'Observable', 'prototype']
  },
  'rxjs/operator/throttle': {
    root: ['Rx', 'Observable', 'prototype']
  },
  'rxjs/operator/throttleTime': {
    root: ['Rx', 'Observable', 'prototype']
  },
  'rxjs/operator/timeInterval': {
    root: ['Rx', 'Observable', 'prototype']
  },
  'rxjs/operator/timeout': {
    root: ['Rx', 'Observable', 'prototype']
  },
  'rxjs/operator/timeoutWith': {
    root: ['Rx', 'Observable', 'prototype']
  },
  'rxjs/operator/timestamp': {
    root: ['Rx', 'Observable', 'prototype']
  },
  'rxjs/operator/toArray': {
    root: ['Rx', 'Observable', 'prototype']
  },
  'rxjs/operator/toPromise': {
    root: ['Rx', 'Observable', 'prototype']
  },
  'rxjs/operator/window': {
    root: ['Rx', 'Observable', 'prototype']
  },
  'rxjs/operator/windowCount': {
    root: ['Rx', 'Observable', 'prototype']
  },
  'rxjs/operator/windowTime': {
    root: ['Rx', 'Observable', 'prototype']
  },
  'rxjs/operator/windowToggle': {
    root: ['Rx', 'Observable', 'prototype']
  },
  'rxjs/operator/windowWhen': {
    root: ['Rx', 'Observable', 'prototype']
  },
  'rxjs/operator/withLatestFrom': {
    root: ['Rx', 'Observable', 'prototype']
  },
  'rxjs/operator/zip': {
    root: ['Rx', 'Observable', 'prototype']
  },
  'rxjs/operator/zipAll': {
    root: ['Rx', 'Observable', 'prototype']
  },
  'rxjs/OuterSubscriber': {
    root: 'Rx'
  },
  'rxjs/ReplaySubject': {
    root: 'Rx'
  },
  'rxjs/Rx': {
    root: 'Rx'
  },
  'rxjs/Scheduler': {
    root: 'Rx'
  },
  'rxjs/scheduler/Action': {
    root: 'Rx'
  },
  'rxjs/scheduler/animationFrame': {
    root: ['Rx', 'Scheduler']
  },
  'rxjs/scheduler/AnimationFrameAction': {
    root: 'Rx'
  },
  'rxjs/scheduler/AnimationFrameScheduler': {
    root: 'Rx'
  },
  'rxjs/scheduler/asap': {
    root: ['Rx', 'Scheduler']
  },
  'rxjs/scheduler/AsapAction': {
    root: 'Rx'
  },
  'rxjs/scheduler/AsapScheduler': {
    root: 'Rx'
  },
  'rxjs/scheduler/async': {
    root: ['Rx', 'Scheduler']
  },
  'rxjs/scheduler/AsyncScheduler': {
    root: 'Rx'
  },
  'rxjs/scheduler/FutureAction': {
    root: 'Rx'
  },
  'rxjs/scheduler/queue': {
    root: ['Rx', 'Scheduler']
  },
  'rxjs/scheduler/QueueAction': {
    root: 'Rx'
  },
  'rxjs/scheduler/QueueScheduler': {
    root: 'Rx'
  },
  'rxjs/scheduler/VirtualTimeScheduler': {
    root: 'Rx'
  },
  'rxjs/Subject': {
    root: 'Rx'
  },
  'rxjs/SubjectSubscription': {
    root: 'Rx'
  },
  'rxjs/Subscriber': {
    root: 'Rx'
  },
  'rxjs/Subscription': {
    root: 'Rx'
  },
  'rxjs/symbol/iterator': {
    root: 'Rx'
  },
  'rxjs/symbol/rxSubscriber': {
    root: 'Rx'
  },
  'rxjs/testing/ColdObservable': {
    root: 'Rx'
  },
  'rxjs/testing/HotObservable': {
    root: 'Rx'
  },
  'rxjs/testing/SubscriptionLog': {
    root: 'Rx'
  },
  'rxjs/testing/SubscriptionLoggable': {
    root: 'Rx'
  },
  'rxjs/testing/TestMessage': {
    root: 'Rx'
  },
  'rxjs/testing/TestScheduler': {
    root: 'Rx'
  },
  'rxjs/util/AnimationFrame': {
    root: 'Rx'
  },
  'rxjs/util/applyMixins': {
    root: 'Rx'
  },
  'rxjs/util/ArgumentOutOfRangeError': {
    root: 'Rx'
  },
  'rxjs/util/assign': {
    root: 'Rx'
  },
  'rxjs/util/EmptyError': {
    root: 'Rx'
  },
  'rxjs/util/errorObject': {
    root: 'Rx'
  },
  'rxjs/util/FastMap': {
    root: 'Rx'
  },
  'rxjs/util/Immediate': {
    root: 'Rx'
  },
  'rxjs/util/isArray': {
    root: 'Rx'
  },
  'rxjs/util/isDate': {
    root: 'Rx'
  },
  'rxjs/util/isFunction': {
    root: 'Rx'
  },
  'rxjs/util/isNumeric': {
    root: 'Rx'
  },
  'rxjs/util/isObject': {
    root: 'Rx'
  },
  'rxjs/util/isPromise': {
    root: 'Rx'
  },
  'rxjs/util/isScheduler': {
    root: 'Rx'
  },
  'rxjs/util/Map': {
    root: 'Rx'
  },
  'rxjs/util/MapPolyfill': {
    root: 'Rx'
  },
  'rxjs/util/noop': {
    root: 'Rx'
  },
  'rxjs/util/not': {
    root: 'Rx'
  },
  'rxjs/util/ObjectUnsubscribedError': {
    root: 'Rx'
  },
  'rxjs/util/root': {
    root: 'Rx'
  },
  'rxjs/util/subscribeToResult': {
    root: 'Rx'
  },
  'rxjs/util/throwError': {
    root: 'Rx'
  },
  'rxjs/util/toSubscriber': {
    root: 'Rx'
  },
  'rxjs/util/tryCatch': {
    root: 'Rx'
  },
  'rxjs/util/UnsubscriptionError': {
    root: 'Rx'
  }
}
```